### PR TITLE
completed lambda for despatch ids  same country

### DIFF
--- a/src/retrieveDespatchesSameCountry.py
+++ b/src/retrieveDespatchesSameCountry.py
@@ -1,0 +1,41 @@
+import json
+import boto3
+from boto3.dynamodb.conditions import Attr
+
+def lambda_handler(event, context):
+    
+    # Retrieve the database 
+    dynamodb = boto3.resource('dynamodb')
+    table = dynamodb.Table('DespatchAdviceTable')
+
+    # Check if event contains the despatch ID, if not return response: 400
+    country = event.get('queryStringParameters', {}).get('country')
+   
+    if not country:
+        return {
+            "statusCode": 400,
+            "message": "Bad Request - Country is not provided"
+        }
+    
+    response = table.scan(
+        FilterExpression=Attr('ShipmentCountry').eq(country)
+    )
+
+    # if item doesn't exist in the response, return response: 404
+    if not response.get('Items', []):
+        return {
+            "statusCode": 404,
+            "message": "Not Found - The country is invalid"
+        }
+    
+    items = response.get('Items', [])
+    #get only the 'ID' field from all items
+    ids = [item['ID'] for item in items]
+
+    return {
+        'statusCode': 200,
+        'despatchAdvices with same ShipmentCountry': {
+            "despatchAdvicesIDs": [f"ID: {id}" for id in ids]
+        }
+    }
+   

--- a/src/retrieveOrderReference.py
+++ b/src/retrieveOrderReference.py
@@ -1,0 +1,35 @@
+import json
+import boto3
+
+def lambda_handler(event, context):
+    
+    # Retrieve the database 
+    dynamodb = boto3.resource('dynamodb')
+    table = dynamodb.Table('DespatchAdviceTable')
+
+    # Check if event contains the despatch ID, if not return response: 400
+    if 'despatchId' not in event.get('pathParameters', {}):
+        return {
+            "statusCode": 400,
+            "body": "Bad Request - The despatch ID is not provided"
+        }
+
+    despatch_id = event['pathParameters']['despatchId']
+
+    response = table.get_item(Key={'ID': despatch_id})
+    # if item doesn't exist in the response, return response: 404
+    if 'Item' not in response:
+        return {
+            "statusCode": 404,
+            "body": "No content - The despatch ID is invalid"
+        }
+
+    # Get the OrderReference attribute string from the Item associated with ID
+    despatch_advice = response['Item']
+    order_reference_details = despatch_advice.get('OrderReference')
+    
+    #return success: 200 + items
+    return {
+        "statusCode": 200,
+        "Items": order_reference_details
+    }


### PR DESCRIPTION
Route:api/v1/despatchAdvice/search/shipped?country=”Name”

Request Body: N/A

Parameters: N/A

Response: 

Success (Status code 200)

List of Despatch advice reference Id in XML format with the same country

Exceptional flows:

401 unauthorised - user is not authorised to get sensitive business information

400 bad request - the country name does not exist

204 No content - no despatch advices found to deliver in that country