### PR TITLE
Test retrieve shipment details

### DIFF
--- a/src/tests/test_RetrieveShipmentDetails.py
+++ b/src/tests/test_RetrieveShipmentDetails.py
@@ -44,7 +44,6 @@ def test_invalid_Id(mock_boto_resource, mock_dynamodb):
 
     assert response["statusCode"] == 404
     mock_table.get_item.assert_called_once_with(Key={"ID": "notexist"})
-    mock_table.delete_item.assert_not_called()
 
 @patch("boto3.resource")
 def test_empty_parameters(mock_boto_resource, mock_dynamodb):
@@ -57,4 +56,3 @@ def test_empty_parameters(mock_boto_resource, mock_dynamodb):
     response = lambda_handler(event, {})
 
     assert response["statusCode"] == 400
-    mock_table.delete_item.assert_not_called()

--- a/src/tests/test_RetrieveShipmentDetails.py
+++ b/src/tests/test_RetrieveShipmentDetails.py
@@ -21,7 +21,7 @@ def test_retrieve_success(mock_boto_resource, mock_dynamodb):
     mock_table.get_item.return_value = {
         "Item": {
             "ID": "123",
-            "Items": "shipmentDetails"
+            "ShipmentDetails": "shipmentDetails"
         }
     }
 
@@ -44,4 +44,17 @@ def test_invalid_Id(mock_boto_resource, mock_dynamodb):
 
     assert response["statusCode"] == 404
     mock_table.get_item.assert_called_once_with(Key={"ID": "notexist"})
+    mock_table.delete_item.assert_not_called()
+
+@patch("boto3.resource")
+def test_empty_parameters(mock_boto_resource, mock_dynamodb):
+    mock_resource, mock_table = mock_dynamodb
+    mock_boto_resource.return_value = mock_resource
+
+    mock_table.get_item.return_value = {}
+
+    event = {"pathParameters": ""}
+    response = lambda_handler(event, {})
+
+    assert response["statusCode"] == 400
     mock_table.delete_item.assert_not_called()

--- a/src/tests/test_RetrieveShipmentDetails.py
+++ b/src/tests/test_RetrieveShipmentDetails.py
@@ -1,0 +1,47 @@
+import pytest
+from unittest.mock import patch, Mock
+
+from retrieveShipmentDetails import lambda_handler
+
+TABLE_NAME = "DespatchAdviceTable"
+
+@pytest.fixture
+def mock_dynamodb():
+    mock_resource = Mock()
+    mock_table = Mock()
+    mock_resource.Table.return_value = mock_table
+
+    return mock_resource, mock_table
+
+@patch("boto3.resource")
+def test_retrieve_success(mock_boto_resource, mock_dynamodb):
+    mock_resource, mock_table = mock_dynamodb
+    mock_boto_resource.return_value = mock_resource
+
+    mock_table.get_item.return_value = {
+        "Item": {
+            "ID": "123",
+            "Items": "shipmentDetails"
+        }
+    }
+
+    event = {"pathParameters": {"despatchId": "123"}}
+    response = lambda_handler(event, {})
+
+    assert response["statusCode"] == 200
+    assert response["Items"] == "shipmentDetails"
+    mock_table.get_item.assert_called_once_with(Key={"ID": "123"})
+
+@patch("boto3.resource")
+def test_invalid_Id(mock_boto_resource, mock_dynamodb):
+    mock_resource, mock_table = mock_dynamodb
+    mock_boto_resource.return_value = mock_resource
+
+    mock_table.get_item.return_value = {}
+
+    event = {"pathParameters": {"despatchId": "notexist"}}
+    response = lambda_handler(event, {})
+
+    assert response["statusCode"] == 404
+    mock_table.get_item.assert_called_once_with(Key={"ID": "notexist"})
+    mock_table.delete_item.assert_not_called()


### PR DESCRIPTION
Returns status code 200 when shipment detail is retrieved.
Returns status code 404 when the parameter doesn't exist in db
Returns status code 400 when the parameter is empty