### PR TITLE
test for retrieveOrderReference.py

### DIFF
--- a/src/tests/test_RetrieveOrderReference.py
+++ b/src/tests/test_RetrieveOrderReference.py
@@ -1,0 +1,56 @@
+import pytest
+from unittest.mock import patch, Mock
+
+from retrieveOrderReference import lambda_handler
+
+@pytest.fixture
+def mock_dynamodb():
+    mock_resource = Mock()
+    mock_table = Mock()
+    mock_resource.Table.return_value = mock_table
+
+    return mock_resource, mock_table
+
+@patch("boto3.resource")
+def test_retrieve_success(mock_boto_resource, mock_dynamodb):
+    mock_resource, mock_table = mock_dynamodb
+    mock_boto_resource.return_value = mock_resource
+
+    mock_table.get_item.return_value = {
+        "Item": {
+            "ID": "123",
+            "OrderReference": "orderReference"
+        }
+    }
+
+    event = {"pathParameters": {"despatchId": "123"}}
+    response = lambda_handler(event, {})
+
+    assert response["statusCode"] == 200
+    assert response["Items"] == "orderReference"
+    mock_table.get_item.assert_called_once_with(Key={"ID": "123"})
+
+@patch("boto3.resource")
+def test_invalid_Id(mock_boto_resource, mock_dynamodb):
+    mock_resource, mock_table = mock_dynamodb
+    mock_boto_resource.return_value = mock_resource
+
+    mock_table.get_item.return_value = {}
+
+    event = {"pathParameters": {"despatchId": "notexist"}}
+    response = lambda_handler(event, {})
+
+    assert response["statusCode"] == 404
+    mock_table.get_item.assert_called_once_with(Key={"ID": "notexist"})
+
+@patch("boto3.resource")
+def test_empty_parameters(mock_boto_resource, mock_dynamodb):
+    mock_resource, mock_table = mock_dynamodb
+    mock_boto_resource.return_value = mock_resource
+
+    mock_table.get_item.return_value = {}
+
+    event = {"pathParameters": ""}
+    response = lambda_handler(event, {})
+
+    assert response["statusCode"] == 400


### PR DESCRIPTION
Returns status code 200 when order reference is retrieved.
Returns status code 404 when the parameter doesn't exist in db
Returns status code 400 when the parameter is empty